### PR TITLE
Create util lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 OUTPUT=main
-CC=gcc
 BIN_PATH=bin
+UNAME := $(shell uname)
+
+# when running on MacOS X, it must use gcc-8
+ifeq ($(UNAME), Darwin)
+	CC=gcc-8
+else
+	CC=gcc
+endif
 
 run: all
 	./$(BIN_PATH)/$(OUTPUT) input/matrix_a input/matrix_b output/matrix_c
 
-all: prepare main.o matrix.o genmatrix.o
+all: prepare main.o matrix.o util.o genmatrix.o
 	$(CC) $(OUTPUT).o matrix.o util.o -fopenmp -o $(BIN_PATH)/$(OUTPUT)
 
 main.o: main.c

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ run: all
 	./$(BIN_PATH)/$(OUTPUT) input/matrix_a input/matrix_b output/matrix_c
 
 all: prepare main.o matrix.o genmatrix.o
-	$(CC) $(OUTPUT).o matrix.o -fopenmp -o $(BIN_PATH)/$(OUTPUT)
+	$(CC) $(OUTPUT).o matrix.o util.o -fopenmp -o $(BIN_PATH)/$(OUTPUT)
 
 main.o: main.c
 	$(CC) -fopenmp -c $(OUTPUT).c
@@ -16,6 +16,9 @@ matrix.o: matrix.c
 
 genmatrix.o: genmatrix.c
 	$(CC) -fopenmp genmatrix.c -o $(BIN_PATH)/genmatrix
+
+util.o: util.c
+	$(CC) -c util.c
 
 prepare: clean
 	mkdir $(BIN_PATH)

--- a/main.c
+++ b/main.c
@@ -1,4 +1,5 @@
 #include "matrix.h"
+#include "util.h"
 #include <string.h>
 
 char *matrix_path_a, *matrix_path_b, *matrix_path_c;

--- a/util.c
+++ b/util.c
@@ -1,6 +1,6 @@
 #include "util.h"
 
-static uint64_t get_time(void)
+uint64_t get_time(void)
 {
     struct timespec time;
     clock_gettime(CLOCK_REALTIME, &time);

--- a/util.c
+++ b/util.c
@@ -1,0 +1,8 @@
+#include "util.h"
+
+static uint64_t get_time(void)
+{
+    struct timespec time;
+    clock_gettime(CLOCK_REALTIME, &time);
+    return ((uint64_t)(time.tv_sec)*1000000000 + (uint64_t)(time.tv_nsec));
+}

--- a/util.h
+++ b/util.h
@@ -1,0 +1,9 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+#include <time.h>
+#include <stdlib.h>
+
+static uint64_t get_time(void);
+
+#endif

--- a/util.h
+++ b/util.h
@@ -4,6 +4,6 @@
 #include <time.h>
 #include <stdlib.h>
 
-static uint64_t get_time(void);
+uint64_t get_time(void);
 
 #endif


### PR DESCRIPTION
# Changelog

- Adds `get_time` function as an util module so we can measure our approaches when using pthreads/openmp and when switching between different algorithms for matrix partitioning.
- Change `Makefile` to compile this project on Mac OS X with gcc-8.